### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/linter-scalastyle.js
+++ b/lib/linter-scalastyle.js
@@ -26,7 +26,7 @@ module.exports = {
     }
   },
 
-  activate: () => {
+  activate() {
     require('atom-package-deps').install();
 
     this.subscriptions = new CompositeDisposable();
@@ -48,11 +48,11 @@ module.exports = {
         scalastyleConfigPath => this.scalastyleConfigPath = scalastyleConfigPath));
   },
 
-  deactivate: () => {
+  deactivate() {
     this.subscriptions.dispose();
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const helpers = require('atom-linter');
     const path = require('path');
     const fs = require('fs');


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.